### PR TITLE
Added units to Ulysses ( except FGM Hires ) and modified util function ( units_attach ) 

### DIFF
--- a/heliopy/data/test/test_data.py
+++ b/heliopy/data/test/test_data.py
@@ -101,11 +101,13 @@ class TestUlysses:
 
     def test_swics_heavy_ions(self):
         df = ulysses.swics_heavy_ions(self.starttime, self.endtime)
-        check_datetime_index(df)
+        check_datetime_index(df.data)
+        check_units(df)
 
     def test_swics_abundances(self):
         df = ulysses.swics_abundances(self.starttime, self.endtime)
-        check_datetime_index(df)
+        check_datetime_index(df.data)
+        check_units(df)
 
 
 @pytest.mark.skipif(no_pycdf, reason='Importing pycdf failed')

--- a/heliopy/data/test/test_data.py
+++ b/heliopy/data/test/test_data.py
@@ -96,7 +96,8 @@ class TestUlysses:
 
     def test_swoops_ions(self):
         df = ulysses.swoops_ions(self.starttime, self.endtime)
-        check_datetime_index(df)
+        check_datetime_index(df.data)
+        check_units(df)
 
     def test_swics_heavy_ions(self):
         df = ulysses.swics_heavy_ions(self.starttime, self.endtime)

--- a/heliopy/data/ulysses.py
+++ b/heliopy/data/ulysses.py
@@ -80,7 +80,8 @@ def swics_heavy_ions(starttime, endtime, try_download=True):
                         ('VEL_MG10', u.km/u.s), ('TEMP_MG10', u.K),
                         ('VEL_SI9', u.km/u.s), ('TEMP_SI9', u.K),
                         ('VEL_SI10', u.km/u.s), ('TEMP_SI10', u.K),
-                        ('VEL_FE11', u.km/u.s), ('TEMP_FE11', u.K)])
+                        ('VEL_FE11', u.km/u.s), ('TEMP_FE11', u.K),
+                        ('DENS_O6'), u.cm**-3])
     return _swics(starttime, endtime, names, product, units, try_download)
 
 

--- a/heliopy/data/ulysses.py
+++ b/heliopy/data/ulysses.py
@@ -73,14 +73,14 @@ def swics_heavy_ions(starttime, endtime, try_download=True):
     for ion in ['ALPHA', 'C6', 'O6', 'NE8', 'MG10', 'SI9', 'SI10', 'FE11']:
         names += ['DENS_' + ion, 'VEL_' + ion, 'TEMP_' + ion]
     product = 'uswimatb'
-    units = OrderedDict([('VEL_ALPHA', u.km/u.s), ('TEMP_ALPHA', u.K),
-                        ('VEL_C6', u.km/u.s), ('TEMP_C6', u.K),
-                        ('VEL_O6', u.km/u.s), ('TEMP_O6', u.K),
-                        ('VEL_NE8', u.km/u.s), ('TEMP_NE8', u.K),
-                        ('VEL_MG10', u.km/u.s), ('TEMP_MG10', u.K),
-                        ('VEL_SI9', u.km/u.s), ('TEMP_SI9', u.K),
-                        ('VEL_SI10', u.km/u.s), ('TEMP_SI10', u.K),
-                        ('VEL_FE11', u.km/u.s), ('TEMP_FE11', u.K),
+    units = OrderedDict([('VEL_ALPHA', u.km / u.s), ('TEMP_ALPHA', u.K),
+                        ('VEL_C6', u.km / u.s), ('TEMP_C6', u.K),
+                        ('VEL_O6', u.km / u.s), ('TEMP_O6', u.K),
+                        ('VEL_NE8', u.km / u.s), ('TEMP_NE8', u.K),
+                        ('VEL_MG10', u.km / u.s), ('TEMP_MG10', u.K),
+                        ('VEL_SI9', u.km / u.s), ('TEMP_SI9', u.K),
+                        ('VEL_SI10', u.km / u.s), ('TEMP_SI10', u.K),
+                        ('VEL_FE11', u.km / u.s), ('TEMP_FE11', u.K),
                         ('DENS_O6', u.cm**-3)])
     return _swics(starttime, endtime, names, product, units, try_download)
 
@@ -117,7 +117,7 @@ def swics_abundances(starttime, endtime, try_download=True):
              'VEL_ALPHA', 'RAT_C6_C5', 'RAT_O7_O6', 'RAT_FE_O', 'CHARGE_FE',
              'N_CYC']
     product = 'uswichst'
-    units = OrderedDict([('VEL_ALPHA', u.km/u.s)])
+    units = OrderedDict([('VEL_ALPHA', u.km / u.s)])
     return _swics(starttime, endtime, names, product, units, try_download)
 
 
@@ -243,8 +243,8 @@ def swoops_ions(starttime, endtime, try_download=True):
     local_base_dir = os.path.join(ulysses_dir, 'swoops', 'ions')
     remote_base_url = ulysses_url
     units = OrderedDict([('T_p_large', u.K), ('T_p_small', u.K),
-                        ('v_t', u.km/u.s), ('v_r', u.km/u.s),
-                        ('v_n', u.km/u.s), ('r', u.au),
+                        ('v_t', u.km / u.s), ('v_r', u.km / u.s),
+                        ('v_n', u.km / u.s), ('r', u.au),
                         ('n_a', u.cm**-3), ('n_p', u.cm**-3)])
 
     def download_func(remote_base_url, local_base_dir,

--- a/heliopy/data/ulysses.py
+++ b/heliopy/data/ulysses.py
@@ -73,7 +73,15 @@ def swics_heavy_ions(starttime, endtime, try_download=True):
     for ion in ['ALPHA', 'C6', 'O6', 'NE8', 'MG10', 'SI9', 'SI10', 'FE11']:
         names += ['DENS_' + ion, 'VEL_' + ion, 'TEMP_' + ion]
     product = 'uswimatb'
-    return _swics(starttime, endtime, names, product, try_download)
+    units = OrderedDict([('VEL_ALPHA', u.km/u.s), ('TEMP_ALPHA', u.K),
+                        ('VEL_C6', u.km/u.s), ('TEMP_C6', u.K),
+                        ('VEL_O6', u.km/u.s), ('TEMP_O6', u.K),
+                        ('VEL_NE8', u.km/u.s), ('TEMP_NE8', u.K),
+                        ('VEL_MG10', u.km/u.s), ('TEMP_MG10', u.K),
+                        ('VEL_SI9', u.km/u.s), ('TEMP_SI9', u.K),
+                        ('VEL_SI10', u.km/u.s), ('TEMP_SI10', u.K),
+                        ('VEL_FE11', u.km/u.s), ('TEMP_FE11', u.K)])
+    return _swics(starttime, endtime, names, product, units, try_download)
 
 
 def swics_abundances(starttime, endtime, try_download=True):
@@ -108,10 +116,11 @@ def swics_abundances(starttime, endtime, try_download=True):
              'VEL_ALPHA', 'RAT_C6_C5', 'RAT_O7_O6', 'RAT_FE_O', 'CHARGE_FE',
              'N_CYC']
     product = 'uswichst'
-    return _swics(starttime, endtime, names, product, try_download)
+    units = OrderedDict([('VEL_ALPHA', u.km/u.s)])
+    return _swics(starttime, endtime, names, product, units, try_download)
 
 
-def _swics(starttime, endtime, names, product, try_download=True):
+def _swics(starttime, endtime, names, product, units=None, try_download=True):
     data = []
     dtimes = util._daysplitinterval(starttime, endtime)
     dirs = []
@@ -153,7 +162,7 @@ def _swics(starttime, endtime, names, product, try_download=True):
     return util.process(
         dirs, fnames, extension, local_base_dir, remote_base_url,
         download_func, processing_func, starttime, endtime,
-        try_download=True)
+        units=units, try_download=True)
 
 
 def fgm_hires(starttime, endtime):
@@ -233,11 +242,8 @@ def swoops_ions(starttime, endtime, try_download=True):
     local_base_dir = os.path.join(ulysses_dir, 'swoops', 'ions')
     remote_base_url = ulysses_url
     units = OrderedDict([('T_p_large', u.K), ('T_p_small', u.K),
-                        ('iqual', u.dimensionless_unscaled),
                         ('v_t', u.km/u.s), ('v_r', u.km/u.s),
                         ('v_n', u.km/u.s), ('r', u.au),
-                        ('hlat', u.dimensionless_unscaled),
-                        ('hlon', u.dimensionless_unscaled),
                         ('n_a', u.cm**-3), ('n_p', u.cm**-3)])
 
     def download_func(remote_base_url, local_base_dir,

--- a/heliopy/data/ulysses.py
+++ b/heliopy/data/ulysses.py
@@ -81,7 +81,7 @@ def swics_heavy_ions(starttime, endtime, try_download=True):
                         ('VEL_SI9', u.km/u.s), ('TEMP_SI9', u.K),
                         ('VEL_SI10', u.km/u.s), ('TEMP_SI10', u.K),
                         ('VEL_FE11', u.km/u.s), ('TEMP_FE11', u.K),
-                        ('DENS_O6'), u.cm**-3])
+                        ('DENS_O6', u.cm**-3)])
     return _swics(starttime, endtime, names, product, units, try_download)
 
 

--- a/heliopy/data/ulysses.py
+++ b/heliopy/data/ulysses.py
@@ -5,10 +5,13 @@ All data is publically available at http://ufa.esac.esa.int/ufa/
 """
 import os
 import pandas as pd
+import sunpy.timeseries as ts
 from datetime import datetime, date
 from urllib.error import HTTPError
 
 from heliopy.data import util
+from collections import OrderedDict
+import astropy.units as u
 from heliopy import config
 
 use_hdf = config['use_hdf']
@@ -229,6 +232,13 @@ def swoops_ions(starttime, endtime, try_download=True):
     extension = '.dat'
     local_base_dir = os.path.join(ulysses_dir, 'swoops', 'ions')
     remote_base_url = ulysses_url
+    units = OrderedDict([('T_p_large', u.K), ('T_p_small', u.K),
+                        ('iqual', u.dimensionless_unscaled),
+                        ('v_t', u.km/u.s), ('v_r', u.km/u.s),
+                        ('v_n', u.km/u.s), ('r', u.au),
+                        ('hlat', u.dimensionless_unscaled),
+                        ('hlon', u.dimensionless_unscaled),
+                        ('n_a', u.cm**-3), ('n_p', u.cm**-3)])
 
     def download_func(remote_base_url, local_base_dir,
                       directory, fname, extension):
@@ -279,7 +289,7 @@ def swoops_ions(starttime, endtime, try_download=True):
     return util.process(
         dirs, fnames, extension, local_base_dir, remote_base_url,
         download_func, processing_func, starttime, endtime,
-        try_download=try_download)
+        units=units, try_download=try_download)
 
 
 def _convert_ulysses_time(data):

--- a/heliopy/data/ulysses.py
+++ b/heliopy/data/ulysses.py
@@ -81,7 +81,14 @@ def swics_heavy_ions(starttime, endtime, try_download=True):
                         ('VEL_SI9', u.km / u.s), ('TEMP_SI9', u.K),
                         ('VEL_SI10', u.km / u.s), ('TEMP_SI10', u.K),
                         ('VEL_FE11', u.km / u.s), ('TEMP_FE11', u.K),
-                        ('DENS_O6', u.cm**-3)])
+                        ('DENS_O6', u.cm**-3), ('DENS_ALPHA', u.dimensionless_unscaled),
+                        ('DENS_C6', u.dimensionless_unscaled),
+                        ('DENS_O6', u.dimensionless_unscaled),
+                        ('DENS_NE8', u.dimensionless_unscaled),
+                        ('DENS_MG10', u.dimensionless_unscaled),
+                        ('DENS_SI9', u.dimensionless_unscaled),
+                        ('DENS_SI10', u.dimensionless_unscaled),
+                        ('DENS_FE11', u.dimensionless_unscaled)])
     return _swics(starttime, endtime, names, product, units, try_download)
 
 
@@ -117,7 +124,12 @@ def swics_abundances(starttime, endtime, try_download=True):
              'VEL_ALPHA', 'RAT_C6_C5', 'RAT_O7_O6', 'RAT_FE_O', 'CHARGE_FE',
              'N_CYC']
     product = 'uswichst'
-    units = OrderedDict([('VEL_ALPHA', u.km / u.s)])
+    units = OrderedDict([('VEL_ALPHA', u.km / u.s),
+                        ('RAT_C6_C5', u.dimensionless_unscaled),
+                        ('RAT_O7_O6', u.dimensionless_unscaled),
+                        ('RAT_FE_O', u.dimensionless_unscaled),
+                        ('CHARGE_FE', u.dimensionless_unscaled),
+                        ('N_CYC', u.dimensionless_unscaled)])
     return _swics(starttime, endtime, names, product, units, try_download)
 
 
@@ -245,7 +257,10 @@ def swoops_ions(starttime, endtime, try_download=True):
     units = OrderedDict([('T_p_large', u.K), ('T_p_small', u.K),
                         ('v_t', u.km / u.s), ('v_r', u.km / u.s),
                         ('v_n', u.km / u.s), ('r', u.au),
-                        ('n_a', u.cm**-3), ('n_p', u.cm**-3)])
+                        ('n_a', u.cm**-3), ('n_p', u.cm**-3),
+                        ('hlat', u.dimensionless_unscaled),
+                        ('hlon', u.dimensionless_unscaled),
+                        ('iqual', u.dimensionless_unscaled)])
 
     def download_func(remote_base_url, local_base_dir,
                       directory, fname, extension):

--- a/heliopy/data/ulysses.py
+++ b/heliopy/data/ulysses.py
@@ -5,7 +5,6 @@ All data is publically available at http://ufa.esac.esa.int/ufa/
 """
 import os
 import pandas as pd
-import sunpy.timeseries as ts
 from datetime import datetime, date
 from urllib.error import HTTPError
 
@@ -258,8 +257,8 @@ def swoops_ions(starttime, endtime, try_download=True):
                         ('v_t', u.km / u.s), ('v_r', u.km / u.s),
                         ('v_n', u.km / u.s), ('r', u.au),
                         ('n_a', u.cm**-3), ('n_p', u.cm**-3),
-                        ('hlat', u.dimensionless_unscaled),
-                        ('hlon', u.dimensionless_unscaled),
+                        ('hlat', u.deg),
+                        ('hlon', u.deg),
                         ('iqual', u.dimensionless_unscaled)])
 
     def download_func(remote_base_url, local_base_dir,

--- a/heliopy/data/util.py
+++ b/heliopy/data/util.py
@@ -139,6 +139,10 @@ def process(dirs, fnames, extension, local_base_dir, remote_base_url,
 
 
 def units_attach(data, units):
+    unit_key = list(units.keys())
+    for column_name in data.columns:
+        if column_name not in unit_key:
+            units[column_name] = u.dimensionless_unscaled
     timeseries_data = ts.TimeSeries(data, units)
     return timeseries_data
 

--- a/heliopy/data/util.py
+++ b/heliopy/data/util.py
@@ -139,10 +139,6 @@ def process(dirs, fnames, extension, local_base_dir, remote_base_url,
 
 
 def units_attach(data, units):
-    unit_key = list(units.keys())
-    for column_name in data.columns:
-        if column_name not in unit_key:
-            units[column_name] = u.dimensionless_unscaled
     timeseries_data = ts.TimeSeries(data, units)
     return timeseries_data
 

--- a/heliopy/data/util.py
+++ b/heliopy/data/util.py
@@ -144,7 +144,8 @@ def units_attach(data, units):
     for column_name in data.columns:
         if column_name not in unit_key:
             units[column_name] = u.dimensionless_unscaled
-            warnings.warn("Column {} has been assigned dimensionless quantity because no unit was assigned in the files. Please assign.".format(column_name), Warning)
+            message = "{} has no units. Assign true unit.".format(column_name)
+            warnings.warn(message, Warning)
     timeseries_data = ts.TimeSeries(data, units)
     return timeseries_data
 

--- a/heliopy/data/util.py
+++ b/heliopy/data/util.py
@@ -12,6 +12,7 @@ import urllib.error as urlerror
 import urllib.request as urlreq
 import astropy.units as u
 import sunpy.timeseries as ts
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -139,6 +140,11 @@ def process(dirs, fnames, extension, local_base_dir, remote_base_url,
 
 
 def units_attach(data, units):
+    unit_key = list(units.keys())
+    for column_name in data.columns:
+        if column_name not in unit_key:
+            units[column_name] = u.dimensionless_unscaled
+            warnings.warn("Column {} has been assigned dimensionless quantity because no unit was assigned in the files. Please assign.".format(column_name), Warning)
     timeseries_data = ts.TimeSeries(data, units)
     return timeseries_data
 


### PR DESCRIPTION
units_attach now automatically assigns the dimensionless unit to the non-assigned units. Ulysses now returns data with units except the FGM Hires since it would be better if it got units attached to it after its conversion to util functions.