### PR TITLE
Removed units from ACE.mfi_h0

### DIFF
--- a/heliopy/data/ace.py
+++ b/heliopy/data/ace.py
@@ -6,7 +6,6 @@ ACE spacecraft homepage can be found at http://www.srl.caltech.edu/ACE/.
 """
 import os
 import pandas as pd
-import sunpy.timeseries as ts
 
 from heliopy.data import util
 from collections import OrderedDict

--- a/heliopy/data/ace.py
+++ b/heliopy/data/ace.py
@@ -87,10 +87,8 @@ def mfi_h0(starttime, endtime):
     product = 'mfi_h0'
     fname = 'h0_mfi'
     version = '06'
-    units = OrderedDict([('Magnitude', u.nT), ('dBrms', u.nT),
-                         ('Q_FLAG', u.dimensionless_unscaled)])
     return _ace(starttime, endtime, instrument, product,
-                fname, units, version=version)
+                fname, version=version)
 
 
 def swe_h0(starttime, endtime):

--- a/heliopy/data/test/test_data.py
+++ b/heliopy/data/test/test_data.py
@@ -141,8 +141,7 @@ class TestAce:
 
     def test_mfi_h0(self):
         df = ace.mfi_h0(self.starttime, self.endtime)
-        check_datetime_index(df.data)
-        check_units(df)
+        check_datetime_index(df)
 
     def test_swe_h0(self):
         df = ace.swe_h0(self.starttime, self.endtime)


### PR DESCRIPTION
Since mfi_h0 downloads CDF files with information about units already available, manually assigning them the units isn't a good way, so removing units from the function.