### PR TITLE
Add remote_fname argument to download functions

### DIFF
--- a/heliopy/data/ace.py
+++ b/heliopy/data/ace.py
@@ -39,7 +39,7 @@ def _ace(starttime, endtime, instrument, product, fname, units=None,
         dirs.append(this_relative_dir)
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         def check_exists():
             # Because the version might be different to the one we guess, work
             # out the downloaded filename

--- a/heliopy/data/artemis.py
+++ b/heliopy/data/artemis.py
@@ -77,7 +77,7 @@ def fgm(probe, rate, coords, starttime, endtime):
         dirs.append(this_relative_dir)
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         remote_url = remote_base_url + str(directory)
         # Now load remotely
         util.load(fname + extension,

--- a/heliopy/data/cassini.py
+++ b/heliopy/data/cassini.py
@@ -109,7 +109,7 @@ def mag_1min(starttime, endtime, coords):
         fnames.append('{}_FGM_{}_1M'.format(year, coords))
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         url = '{}/{}'.format(base_url, year)
         util._download_remote(url,
                               fname + extension,
@@ -185,7 +185,7 @@ def mag_hires(starttime, endtime, try_download=True):
         fnames.append(str(year)[2:] + doy + '_FGM_{}'.format(coords))
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
             url = remote_base_url + '/' + str(directory)
             util._download_remote(url, fname + extension,
                                   local_base_dir / directory)

--- a/heliopy/data/cluster.py
+++ b/heliopy/data/cluster.py
@@ -61,7 +61,8 @@ def _load(probe, starttime, endtime, instrument, product_id,
     remote_base_url = csa_url
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension, download_info):
+                      directory, fname, remote_fname, extension,
+                      download_info):
         starttime, endtime = download_info
         _download(probe, starttime, endtime, instrument, product_id)
 

--- a/heliopy/data/dscovr.py
+++ b/heliopy/data/dscovr.py
@@ -49,7 +49,7 @@ def mag_h0(starttime, endtime):
     remote_base_url = dscovr_url
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
             remote_url = remote_base_url + str(directory)
             filename = fname + extension
             local_dir = local_base_dir / directory

--- a/heliopy/data/helios.py
+++ b/heliopy/data/helios.py
@@ -908,7 +908,7 @@ def corefit(probe, starttime, endtime, try_download=True):
     remote_base_url = 'ftp://apollo.ssl.berkeley.edu/pub/helios-data/'
 
     def download_func(remote_base_url, local_base_dir, directory,
-                      fname, extension):
+                      fname, remote_fname, extension):
         remote_url = '{}{}'.format(remote_base_url, directory)
         util.load(fname + extension,
                   local_base_dir / directory,
@@ -996,7 +996,7 @@ def merged(probe, starttime, endtime, try_download=True):
         dirs.append('')
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         remote_url = remote_base_url + str(directory)
         local_dir = local_base_dir / directory
         util._download_remote(remote_url, fname + extension, local_dir)
@@ -1070,7 +1070,7 @@ def mag_4hz(probe, starttime, endtime, try_download=True):
         fnames.append('he{}1s{}{:03}'.format(probe, year - 1900, doy))
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         local_dir = local_base_dir / directory
         remote_dir = ('pub/helios-data/E2_experiment/'
                       'Data_Cologne_Nov2016_bestdata/'
@@ -1157,7 +1157,7 @@ def mag_ness(probe, starttime, endtime, try_download=True):
         fnames.append('h{}{}{:03}'.format(probe, year - 1900, doy))
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         remote_url = remote_base_url + str(directory)
         local_dir = local_base_dir / directory
         filename = fname + extension

--- a/heliopy/data/imp.py
+++ b/heliopy/data/imp.py
@@ -101,7 +101,7 @@ def merged(probe, starttime, endtime, try_download=True):
             dirs.append('')
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         filename = fname + extension
         local_dir = path.Path(local_base_dir) / directory
         util._download_remote(remote_base_url, filename, local_dir)
@@ -197,7 +197,7 @@ def mitplasma_h0(probe, starttime, endtime, try_download=True):
     remote_base_url = imp_url
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         remote_url = remote_base_url + str(directory)
         filename = fname + extension
         local_dir = local_base_dir / directory
@@ -254,7 +254,7 @@ def mag320ms(probe, starttime, endtime, try_download=True):
     remote_base_url = imp_url
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         remote_url = remote_base_url + str(directory)
         filename = fname + extension
         local_dir = local_base_dir / directory
@@ -330,7 +330,7 @@ def mag15s(probe, starttime, endtime, verbose=False, try_download=True):
     remote_base_url = imp_url
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         remote_url = remote_base_url + str(directory)
         filename = fname + extension
         local_dir = local_base_dir / directory

--- a/heliopy/data/messenger.py
+++ b/heliopy/data/messenger.py
@@ -52,7 +52,7 @@ def mag_rtn(starttime, endtime, try_download=True):
     remote_base_url = remote_mess_dir
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         remote_url = remote_base_url + str(directory)
         filename = fname + extension
         local_dir = local_base_dir / directory

--- a/heliopy/data/omni.py
+++ b/heliopy/data/omni.py
@@ -118,7 +118,7 @@ def low(starttime, endtime, try_download=True):
         dirs.append(local_base_dir)
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         url = '{}'.format(remote_base_url)
         util._download_remote(url,
                               fname + extension,

--- a/heliopy/data/ulysses.py
+++ b/heliopy/data/ulysses.py
@@ -142,7 +142,7 @@ def _swics(starttime, endtime, names, product, units=None, try_download=True):
     remote_base_url = ulysses_url
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         local_dir = local_base_dir / directory
         swics_options = url_options
         swics_options['FILE_NAME'] = fname + extension
@@ -203,7 +203,7 @@ def fgm_hires(starttime, endtime, try_download=True):
                          ('Bz', u.nT), ('|B|', u.nT)])
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         local_dir = local_base_dir / directory
         fgm_options = url_options
         fgm_options['FILE_NAME'] = fname + extension
@@ -269,7 +269,7 @@ def swoops_ions(starttime, endtime, try_download=True):
                         ('iqual', u.dimensionless_unscaled)])
 
     def download_func(remote_base_url, local_base_dir,
-                      directory, fname, extension):
+                      directory, fname, remote_fname, extension):
         local_dir = local_base_dir / directory
         swoops_options = url_options
         year = fname[1:3]

--- a/heliopy/data/util.py
+++ b/heliopy/data/util.py
@@ -130,8 +130,8 @@ def process(dirs, fnames, extension, local_base_dir, remote_base_url,
                 if dl_info is not None:
                     args = (dl_info,)
                 new_fname = download_func(remote_base_url, local_base_dir,
-                                          directory, fname, extension,
-                                          *args)
+                                          directory, fname, remote_fname,
+                                          extension,  *args)
                 if new_fname is not None:
                     fname = new_fname
                     local_file = local_base_dir / directory / fname

--- a/heliopy/data/util.py
+++ b/heliopy/data/util.py
@@ -102,7 +102,7 @@ def process(dirs, fnames, extension, local_base_dir, remote_base_url,
     remote_fnames : list of str, optional
         If the remote filenames are different from the desired downloaded
         filenames, this should be a list of length ``len(fnames)`` with the
-        files to be downloaded. The ordering must be the same as *fnames.
+        files to be downloaded. The ordering must be the same as *fnames*.
 
     Returns
     -------

--- a/heliopy/data/util.py
+++ b/heliopy/data/util.py
@@ -134,7 +134,7 @@ def process(dirs, fnames, extension, local_base_dir, remote_base_url,
                     args = (dl_info,)
                 new_fname = download_func(remote_base_url, local_base_dir,
                                           directory, fname, remote_fname,
-                                          extension,  *args)
+                                          extension, *args)
                 if new_fname is not None:
                     fname = new_fname
                     local_file = local_base_dir / directory / fname

--- a/heliopy/data/util.py
+++ b/heliopy/data/util.py
@@ -113,7 +113,10 @@ def process(dirs, fnames, extension, local_base_dir, remote_base_url,
     data = []
     if download_info == []:
         download_info = [None] * len(dirs)
-    for directory, fname, dl_info in zip(dirs, fnames, download_info):
+    if remote_fnames is None:
+        remote_fnames = fnames.copy()
+    zips = zip(dirs, fnames, remote_fnames, download_info)
+    for directory, fname, remote_fname, dl_info in zips:
         local_dir = local_base_dir / directory
         local_file = local_base_dir / directory / fname
         # Fist try to load local HDF file

--- a/heliopy/data/util.py
+++ b/heliopy/data/util.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 def process(dirs, fnames, extension, local_base_dir, remote_base_url,
             download_func, processing_func, starttime, endtime,
             try_download=True, units=None,
-            processing_kwargs={}, download_info=[]):
+            processing_kwargs={}, download_info=[], remote_fnames=None):
     """
     The main utility method for systematically loading, downloading, and saving
     data.
@@ -57,13 +57,14 @@ def process(dirs, fnames, extension, local_base_dir, remote_base_url,
         - The remote base url
         - The local base directory
         - The relative directory (relative to the base url)
-        - A filename
+        - The local filename to download to
+        - The remote filename
         - A file extension
 
         and downloads the remote file. The signature must be::
 
             def download_func(remote_base_url, local_base_dir,
-                              directory, fname, extension)
+                              directory, fname, remote_fname, extension)
 
         The function can also return the filename of the file it downloaded,
         if this is different to the filename it is given. *download_func*
@@ -98,6 +99,10 @@ def process(dirs, fnames, extension, local_base_dir, remote_base_url,
     download_info : list, optional
         A list with the same length as *fnames*, which contains extra info
         that is handed to *download_func* for each file individually.
+    remote_fnames : list of str, optional
+        If the remote filenames are different from the desired downloaded
+        filenames, this should be a list of length ``len(fnames)`` with the
+        files to be downloaded. The ordering must be the same as *fnames.
 
     Returns
     -------

--- a/heliopy/data/wind.py
+++ b/heliopy/data/wind.py
@@ -40,7 +40,7 @@ def _load_wind_cdf(starttime, endtime, instrument, data_product,
     remote_base_url = remote_wind_dir
 
     def download_func(remote_base_url, local_base_dir, directory,
-                      fname, extension):
+                      fname, remote_fname, extension):
         remote_url = '{}{}'.format(remote_base_url, directory)
         util.load(fname + extension,
                   local_base_dir / directory,
@@ -148,7 +148,7 @@ def swe_h3(starttime, endtime):
     remote_base_url = remote_wind_dir
 
     def download_func(remote_base_url, local_base_dir, directory,
-                      fname, extension):
+                      fname, remote_fname, extension):
         remote_url = '{}{}'.format(remote_base_url, directory)
         util.load(fname + extension,
                   local_base_dir / directory,
@@ -250,7 +250,7 @@ def _mfi(starttime, endtime, version, units=None, ignore=None):
     remote_base_url = remote_wind_dir
 
     def download_func(remote_base_url, local_base_dir, directory,
-                      fname, extension):
+                      fname, remote_fname, extension):
         remote_url = '{}{}'.format(remote_base_url, directory)
         util.load(fname + extension,
                   local_base_dir / directory,
@@ -318,7 +318,7 @@ def threedp_pm(starttime, endtime):
     remote_base_url = remote_wind_dir
 
     def download_func(remote_base_url, local_base_dir, directory,
-                      fname, extension):
+                      fname, remote_fname, extension):
         remote_url = remote_base_url + str(directory)
         util.load(fname + extension,
                   local_base_dir / directory,
@@ -370,7 +370,7 @@ def threedp_sfpd(starttime, endtime):
     remote_base_url = remote_wind_dir
 
     def download_func(remote_base_url, local_base_dir, directory,
-                      fname, extension):
+                      fname, remote_fname, extension):
         remote_url = remote_base_url + str(directory)
         util.load(fname + extension,
                   local_base_dir / directory,


### PR DESCRIPTION
This gives the option for `download_func` to download a file to a different filename than the one on the remote server. Part 1 of another overhaul of the downloading functionality.