### PR TITLE
Remove python 3.6 build on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ environment:
     NUMPY_VERSION: "stable"
 
   matrix:
-    - PYTHON_VERSION: "3.6"
     - PYTHON_VERSION: "3.7"
 
 matrix:


### PR DESCRIPTION
Appveyor doesn't run jobs in parallel, so having 2 jobs takes ages. I think we can just keep the python 3.7 job.