### PR TITLE
Added @deprecated

### DIFF
--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -6,3 +6,4 @@ requests
 sunpy
 spiceypy
 wget
+deprecated


### PR DESCRIPTION
Usage 
```
from deprecated import deprecated

@deprecated(reason=None)
def some_func():
```

Hi, @dstansby I added this module to address #604 