### PR TITLE
Added logo in Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ heliopy.egg-info*
 *.DS_Store*
 build/*
 dist/*
+
+env

--- a/doc/source/guide/index.rst
+++ b/doc/source/guide/index.rst
@@ -9,3 +9,4 @@ HelioPy guide
    citing
    whatsnew
    code-of-conduct
+   logo

--- a/doc/source/guide/logo.rst
+++ b/doc/source/guide/logo.rst
@@ -3,6 +3,10 @@ Logo
 
 The following logos of Heliopy are avaialble for use while citing Heliopy.
 
+The logos have been licensed under CC-BY-4.0_.
+
+.. _CC-BY-4.0: https://creativecommons.org/licenses/by/4.0/
+
 =================
 Rectangular Logo
 =================

--- a/doc/source/guide/logo.rst
+++ b/doc/source/guide/logo.rst
@@ -1,0 +1,23 @@
+Logo
+======
+
+The following logos of Heliopy are avaialble for use while citing Heliopy.
+
+=================
+Rectangular Logo
+=================
+
+.. image:: https://raw.githubusercontent.com/heliopython/heliopy/master/artwork/logo_rectangle.png
+
+================
+Circular Logo
+================
+
+.. image:: https://raw.githubusercontent.com/heliopython/heliopy/master/artwork/logo_circle.png
+
+=======
+Favicon
+=======
+
+.. image :: https://raw.githubusercontent.com/heliopython/heliopy/master/artwork/favicon.ico
+


### PR DESCRIPTION
I have added logo in the documentation under the `doc/source/guide/`. All three variants, rectangle circle and favicon have been added.

Do we need to specify a Creative commons license for the logos?

This solves #559 