### PR TITLE
fix overlap in timeseries plot

### DIFF
--- a/examples/plot_timeseries.py
+++ b/examples/plot_timeseries.py
@@ -43,4 +43,5 @@ for r in ion_ratios:
 
 axs[1].set_yscale('log')
 axs[1].legend()
+fig.autofmt_xdate()
 plt.show()


### PR DESCRIPTION
Fixes #703 
The plot is now obtained as below:
![Figure_1](https://user-images.githubusercontent.com/24570709/57851884-5355ab80-77ff-11e9-98cf-7474976e5de9.png)
