### PR TITLE
Add PSP 4 samples/cycle download routine

### DIFF
--- a/heliopy/data/psp.py
+++ b/heliopy/data/psp.py
@@ -93,6 +93,17 @@ class _FIELDSmag_RTN_1min_Downloader(_FIELDSDownloader):
         datestr = interval.start.strftime('%Y%m%d')
         return f'psp_fld_l2_mag_rtn_1min_{datestr}_v01.cdf'
 
+class _FIELDSmag_RTN_4_Per_Cycle_Downloader(_FIELDSDownloader):
+    epoch_label = 'epoch_mag_RTN_4_Sa_per_Cyc'
+
+    def local_dir(self, interval):
+        year = interval.start.strftime('%Y')
+        return pathlib.Path('psp') / 'fields' / 'l2' / 'mag_rtn_4_per_cycle' / year
+
+    def fname(self, interval):
+        datestr = interval.start.strftime('%Y%m%d')
+        return f'psp_fld_l2_mag_rtn_4_sa_per_cyc_{datestr}_v01.cdf'
+
 
 class _FIELDSmag_RTN_Downloader(_FIELDSDownloader):
     epoch_label = 'epoch_mag_RTN'
@@ -129,6 +140,12 @@ def fields_mag_rtn_1min(starttime, endtime):
     dl = _FIELDSmag_RTN_1min_Downloader()
     return dl.load(starttime, endtime)
 
+def fields_mag_rtn_4_per_cycle(starttime, endtime):
+    """
+    4 Samples per spacecraft clock cycle
+    """
+    dl = _FIELDSmag_RTN_4_Per_Cycle_Downloader()
+    return dl.load(starttime, endtime)
 
 def fields_mag_rtn(starttime, endtime):
     """

--- a/heliopy/data/test/test_psp.py
+++ b/heliopy/data/test/test_psp.py
@@ -14,6 +14,7 @@ endtime = datetime(2018, 12, 19, 1)
 @pytest.mark.parametrize('func', [psp.sweap_spc_l2,
                                   psp.sweap_spc_l3,
                                   psp.fields_mag_rtn_1min,
+                                  psp.fields_mag_rtn_4_per_cycle,
                                   psp.fields_mag_rtn])
 def test_psp(func):
     df = func(starttime, endtime)


### PR DESCRIPTION
Simple carbon copy of mag_RTN and mag_RTN_1min downloaders to allow downloading of 4 sa/cyc data product from PSP /FIELDS.  This is an intermediate sized file with file size ~ 10 MB/day at perihelion (compare to 240 MB/day for mag_RTN)

The only non triviality is that the spdf file names and the FIELDS SOC filenames (i.e. the ones inside the cdf files ) are slightly different (_4_per_cycle_ vs. 4_Sa_per_Cyc_), but pretty sure it's ironed out since this passes `test/test_psp.py`