### PR TITLE
Add mec to the allowed instruments for MMS

### DIFF
--- a/heliopy/data/mms.py
+++ b/heliopy/data/mms.py
@@ -23,7 +23,7 @@ dl_url = mms_url + '/files/api/v1/download/science'
 
 def _validate_instrument(instrument):
     allowed_instruments = ['afg', 'aspoc', 'dfg', 'dsp', 'edi',
-                           'edp', 'fgm', 'fpi', 'fields', 'scm', 'sdp', ]
+                           'edp', 'fgm', 'fpi', 'fields', 'scm', 'sdp', 'mec']
     if instrument not in allowed_instruments:
         raise ValueError(
             'Instrument {} not in list of allowed instruments: {}'.format(


### PR DESCRIPTION
The 'mec' instrument allows getting the spacecraft position and attitude with "mms1_mec_r_gse" and "mms1_mec_quat_eci_to_dbcs" for instance.
