### PR TITLE
Make carrington frame consistent with sunpy 2.0

### DIFF
--- a/heliopy/spice/spice.py
+++ b/heliopy/spice/spice.py
@@ -6,6 +6,8 @@ from spiceypy.utils import support_types as spiceytypes
 import astropy.time as time
 import astropy.units as u
 import astropy.coordinates as astrocoords
+
+import sunpy
 import sunpy.coordinates as suncoords
 import sunpy.sun.constants
 
@@ -266,6 +268,16 @@ class Trajectory:
                 f'(currently set to {self._abcorr})')
 
         frame = spice_astropy_frame_mapping[self._frame][0]
+
+        # Error if sunpy < 2 due to changes in Heliographic coordinates then
+        if (frame == suncoords.HeliographicCarrington and
+                int(sunpy.__version__[0]) < 2):
+            raise NotImplementedError(
+                'Converting to Carrington coordinates only works for '
+                f'sunpy versions >= 2.0 (found sunpy {sunpy.__version__} '
+                'installed)'
+            )
+
         kwargs = spice_astropy_frame_mapping[self._frame][1]
         coords = astrocoords.SkyCoord(
             self.x, self.y, self.z,

--- a/heliopy/spice/spice.py
+++ b/heliopy/spice/spice.py
@@ -178,11 +178,11 @@ class Trajectory:
         # Spice needs a funny set of times
         fmt = '%Y %b %d, %H:%M:%S'
         spice_times = [spiceypy.str2et(time.strftime(fmt)) for time in times]
-        abcorr = str(abcorr)
+        self._abcorr = str(abcorr)
 
         # Do the calculation
         pos_vel, lightTimes = spiceypy.spkezr(
-            self.target.name, spice_times, frame, abcorr,
+            self.target.name, spice_times, frame, self._abcorr,
             observing_body)
 
         positions = np.array(pos_vel)[:, :3] * u.km
@@ -259,6 +259,11 @@ class Trajectory:
             raise ValueError(f'Current frame "{self._frame}" not in list of '
                              f'known coordinate frames implemented in astropy '
                              f'or sunpy ({spice_astropy_frame_mapping})')
+        if self._abcorr.lower() != 'none':
+            raise NotImplementedError(
+                'Can only convert to astropy coordinates if the aberration '
+                'correction is set to "none" '
+                f'(currently set to {self._abcorr})')
 
         frame = spice_astropy_frame_mapping[self._frame][0]
         kwargs = spice_astropy_frame_mapping[self._frame][1]

--- a/heliopy/spice/test/test_spice.py
+++ b/heliopy/spice/test/test_spice.py
@@ -112,3 +112,11 @@ def test_spice_sunpy_equivalence():
     rtol = 1e-6
     assert u.allclose(earth.coords.lon, l0, rtol=rtol)
     assert u.allclose(earth.coords.lat, b0, rtol=rtol)
+
+
+def test_coord_err():
+    t = ['1992-12-21']
+    earth = spice.Trajectory('Earth')
+    earth.generate_positions(t, 'Sun', 'IAU_SUN', abcorr='LT')
+    with pytest.raises(NotImplementedError):
+        earth.coords

--- a/heliopy/spice/test/test_spice.py
+++ b/heliopy/spice/test/test_spice.py
@@ -1,9 +1,14 @@
 import datetime
 
 from astropy.time import Time
+import astropy.units as u
 from astropy.utils.exceptions import ErfaWarning
+from astropy.coordinates import Latitude
 import numpy as np
+import sunpy.coordinates.sun
+
 import pytest
+
 
 import heliopy.spice as spice
 import heliopy.data.spice as spicedata
@@ -92,3 +97,18 @@ def test_kernel():
         datetime.datetime(1981, 9, 30, 1, 29, 54, 1651,
                           tzinfo=datetime.timezone.utc)
     ]
+
+
+def test_spice_sunpy_equivalence():
+    # Check that SPICE coordinates and the sunpy coordinates we associate
+    # with those coordinates are the same
+    t = ['1992-12-21']
+    b0 = Latitude(sunpy.coordinates.sun.B0(t))
+    l0 = sunpy.coordinates.sun.L0(t, light_travel_time_correction=False)
+
+    earth = spice.Trajectory('Earth')
+    earth.generate_positions(t, 'Sun', 'IAU_SUN')
+
+    rtol = 1e-6
+    assert u.allclose(earth.coords.lon, l0, rtol=rtol)
+    assert u.allclose(earth.coords.lat, b0, rtol=rtol)


### PR DESCRIPTION
xref #910 

Todo:

- [x] Work out what to do with sunpy<2 (either error or provide support)
- [x] Parametrize test to check both with and without light travel time correction
- [x] Test transforming from ICRS to HeliographicCarrington
- [x] Add hypothesis testing to test multiple times
- [x] Write changelog