### PR TITLE
Suggestion for stereo submodule

### DIFF
--- a/heliopy/data/helper.py
+++ b/heliopy/data/helper.py
@@ -141,6 +141,7 @@ def cdf_dict(unit_string):
     ionic_charge = u.def_unit('Charged State', 1.6021766 * (10**-19) * u.C)
 
     units = OrderedDict([('ratio', u.dimensionless_unscaled),
+                        ('Na', u.dimensionless_unscaled),
                         ('NOTEXIST', u.dimensionless_unscaled),
                         ('Unitless', u.dimensionless_unscaled),
                         ('unitless', u.dimensionless_unscaled),
@@ -206,6 +207,7 @@ def cdf_dict(unit_string):
                         ('deg (>200)', u.deg),
 
                         ('Deg K', u.K),
+                        ('deg_K', u.K),
                         ('#/{cc*(cm/s)^3}', (u.cm**3 * (u.cm / u.s)**3)**-1),
                         ('sec', u.s),
                         ('Samples/s', 1 / u.s),

--- a/heliopy/data/test/test_stereo.py
+++ b/heliopy/data/test/test_stereo.py
@@ -10,8 +10,9 @@ starttime = datetime(2010, 12, 19)
 endtime = datetime(2010, 12, 20)
 
 
-@pytest.mark.parametrize('func', [stereo.coho1hr_merged])
-@pytest.mark.parametrize('sc', ['A', 'B'])
+@pytest.mark.parametrize('func', [stereo.mag_l1_rtn,
+                                  stereo.magplasma_l2])
+@pytest.mark.parametrize('sc', ['sta', 'stb'])
 def test_psp(func, sc):
     df = func(sc, starttime, endtime)
     check_data_output(df)


### PR DESCRIPTION
Hi David,

I stripped an easily-merged version of the submodule from my SEP stuff with a couple of magnetic field data downloaders, would it be possible to use this instead of the one that you started? 

The rationale for the "STA" instead of "A" for spacecraft is that I'm using the function _identifier_select that way in a couple of places in the SEP functions to be added. 

As for the dl.load() in calling functions instead of _stereo(), one of the SEP instruments needs data modifications after the dl.load().

I removed the coho function as assumed it was a placeholder, happy to return it in place!

Cheers,

Timo
