### PR TITLE
mms.py: fix bug when list of files is empty

### DIFF
--- a/heliopy/data/mms.py
+++ b/heliopy/data/mms.py
@@ -97,8 +97,11 @@ def available_files(probe, instrument, starttime, endtime, data_rate='',
     query['end_date'] = end_date
 
     r = requests.get(query_url, params=query)
-    files = r.text.split(',')
-    files = filter_time(files, starttime, endtime)
+    if r.text:
+        files = r.text.split(',')
+        files = filter_time(files, starttime, endtime)
+    else:
+        files = None
     return files
 
 


### PR DESCRIPTION
Before, an empty list would be processed by filter_time, which would throw an
error due to accessing `optdesc = parts[4]`. Now the list of files is set to `None` instead.