### PR TITLE
mms.py available_files(): return [] instead of None

### DIFF
--- a/heliopy/data/mms.py
+++ b/heliopy/data/mms.py
@@ -101,7 +101,7 @@ def available_files(probe, instrument, starttime, endtime, data_rate='',
         files = r.text.split(',')
         files = filter_time(files, starttime, endtime)
     else:
-        files = None
+        files = []
     return files
 
 


### PR DESCRIPTION
A small correction to my previous pull request. The `available_files()` method now returns an empty list `[]` instead of None, which fixes an error in `download_files()` (which tries to iterate over the result of available_files).